### PR TITLE
Add Basket service and limit SignalR to Notification.Api

### DIFF
--- a/Basket.Api/Basket.Api.csproj
+++ b/Basket.Api/Basket.Api.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Microservices.Basket.Api</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
+  </ItemGroup>
+</Project>

--- a/Basket.Api/Program.cs
+++ b/Basket.Api/Program.cs
@@ -24,20 +24,20 @@ app.UseCors();
 app.Run();
 
 [ApiController]
-public class OrderController : ControllerBase
+public class BasketController : ControllerBase
 {
-    private readonly ILogger<OrderController> _logger;
+    private readonly ILogger<BasketController> _logger;
 
-    public OrderController(ILogger<OrderController> logger)
+    public BasketController(ILogger<BasketController> logger)
     {
         _logger = logger;
     }
 
-    [HttpPost("/orders")]
-    [Topic("pubsub", "orders")]
-    public async Task<IActionResult> ReceiveOrder([FromBody] object payload)
+    [HttpPost("/baskets")]
+    [Topic("pubsub", "baskets")]
+    public async Task<IActionResult> ReceiveBasket([FromBody] object payload)
     {
-        _logger.LogInformation("Order received.");
+        _logger.LogInformation("Basket received.");
         return Ok();
     }
 }

--- a/Basket.Api/Properties/launchSettings.json
+++ b/Basket.Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Basket.Api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:32782;http://localhost:32783"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Microservices Solution
 
-This repository now contains multiple .NET 9 Web API microservices. `Notification.Api` and `Orders.Api` both use Dapr and SignalR for messaging. The projects are included in the `microservices.sln` solution file.
+This repository now contains three .NET 9 Web API microservices. `Notification.Api` uses Dapr and SignalR to broadcast messages to connected clients. `Orders.Api` and the new `Basket.Api` expose simple Dapr endpoints without SignalR. All projects are included in the `microservices.sln` solution file.
 
 Open `microservices.sln` with Visual Studio 2022 or later to work with the services.

--- a/microservices.sln
+++ b/microservices.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Notification.Api", "Notific
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orders.Api", "Orders.Api\\Orders.Api.csproj", "{9C289FAD-DCC4-4A86-8D8E-32804A190C18}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Basket.Api", "Basket.Api\\Basket.Api.csproj", "{FAF75FF9-2BC2-4D13-BF09-6CC29DB96C01}"
+EndProject
 Global
 		GlobalSection(SolutionConfigurationPlatforms) = preSolution
 			Debug|Any CPU = Debug|Any CPU
@@ -16,11 +18,15 @@ Global
 			{AB2B12B8-800E-46C8-9A40-2F402D6368DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 			{AB2B12B8-800E-46C8-9A40-2F402D6368DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 			{AB2B12B8-800E-46C8-9A40-2F402D6368DD}.Release|Any CPU.Build.0 = Release|Any CPU
-			{9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-			{9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Debug|Any CPU.Build.0 = Debug|Any CPU
-			{9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Release|Any CPU.ActiveCfg = Release|Any CPU
-			{9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Release|Any CPU.Build.0 = Release|Any CPU
-		EndGlobalSection
+                        {9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {9C289FAD-DCC4-4A86-8D8E-32804A190C18}.Release|Any CPU.Build.0 = Release|Any CPU
+                        {FAF75FF9-2BC2-4D13-BF09-6CC29DB96C01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        {FAF75FF9-2BC2-4D13-BF09-6CC29DB96C01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        {FAF75FF9-2BC2-4D13-BF09-6CC29DB96C01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        {FAF75FF9-2BC2-4D13-BF09-6CC29DB96C01}.Release|Any CPU.Build.0 = Release|Any CPU
+                EndGlobalSection
 		GlobalSection(SolutionProperties) = preSolution
 HideSolutionNode = FALSE
 		EndGlobalSection


### PR DESCRIPTION
## Summary
- remove SignalR usage from Orders.Api
- introduce new Basket.Api microservice
- update solution file and README

## Testing
- `dotnet build microservices.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3ad1077c832795f3d104c9c331a7